### PR TITLE
Add Meal Parsing Generator CRON Job for Monday 10 A.M

### DIFF
--- a/.github/workflows/parse_generate_meal_plan.yml
+++ b/.github/workflows/parse_generate_meal_plan.yml
@@ -2,8 +2,8 @@ name: Generate and Commit File
 
 on:
   schedule:
-    # Run every Monday at 10:00 AM UTC
-    - cron: "0 10 * * 1"
+    # Run every Monday at 8:00 AM Turkish time (EET)
+    - cron: "0 5 * * 1" # 5:00 UTC = 8:00 EET
   push:
     branches:
       - main

--- a/.github/workflows/parse_generate_meal_plan.yml
+++ b/.github/workflows/parse_generate_meal_plan.yml
@@ -1,9 +1,12 @@
 name: Generate and Commit File
 
 on:
+  schedule:
+    # Run every Monday at 10:00 AM UTC
+    - cron: "0 10 * * 1"
   push:
     branches:
-      - "*"
+      - main
 
 jobs:
   generate-and-commit:

--- a/webapp/mealplans/meal_plan_week_8_2024.json
+++ b/webapp/mealplans/meal_plan_week_8_2024.json
@@ -390,8 +390,8 @@
           "en": "Pastry filled with spinach"
         },
         {
-          "tr": "Zeytinyağlı Enginar",
-          "en": "Artichoke cooked with olive oil"
+          "tr": "Zeytinyağlı Bamya",
+          "en": "Okra cooked with olive oil"
         },
         {
           "tr": "Amasra Salata",


### PR DESCRIPTION
GitHub Action set up to create the meal parsing data and save it back into the repo, to be later served on GithubPages. 

Resolves #4 